### PR TITLE
Fix switch label

### DIFF
--- a/demo/demo-schemas/sandbox.js
+++ b/demo/demo-schemas/sandbox.js
@@ -1,0 +1,546 @@
+/* eslint-disable camelcase */
+import { componentTypes as components, validatorTypes as validators } from '@data-driven-forms/react-form-renderer';
+
+const output = {
+  title: 'Testing dialog',
+  description: 'Description of testing Dialog',
+  fields: [
+    {
+      fields: [
+        {
+          title: 'Tab 1',
+          description: 'Text boxes and text areas',
+          key: '553',
+          fields: [
+            {
+              title: 'Text boxes',
+              key: '637',
+              fields: [
+                {
+                  name: 'text_box_1',
+                  label: 'Text Box',
+                  title: 'Text Box',
+                  component: components.SWITCH,
+                  assignFieldProvider: true,
+                },
+                {
+                  name: 'text_box_111',
+                  label: 'Text Box',
+                  title: 'Text Box',
+                  component: components.SWITCH,
+                  assignFieldProvider: true,
+                  isDisabled: true,
+                },
+                {
+                  name: 'text_box_1111',
+                  label: 'Text Box',
+                  title: 'Text Box',
+                  component: components.SWITCH,
+                  assignFieldProvider: true,
+                  isReadOnly: true,
+                },
+                {
+                  name: 'text_box_11111',
+                  label: 'Text Box',
+                  title: 'Text Box',
+                  component: components.SWITCH,
+                  assignFieldProvider: true,
+                  placeholder: 'hello',
+                  onText: 'turned on',
+                  offText: 'turnedOff',
+                },
+                {
+                  name: 'text_box_2',
+                  label: 'Text Box with help',
+                  title: 'Text Box with help',
+                  helperText: 'Helper text',
+                  component: components.TEXT_FIELD,
+                },
+                {
+                  name: 'text_box_3',
+                  label: 'Text Box required',
+                  title: 'Text Box required',
+                  isRequired: true,
+                  component: components.TEXT_FIELD,
+                  validate: [
+                    { type: validators.REQUIRED },
+                  ],
+                },
+                {
+                  name: 'text_box_4',
+                  label: 'Text Box readonly',
+                  title: 'Text Box readonly',
+                  isReadOnly: true,
+                  component: components.TEXT_FIELD,
+                },
+                {
+                  name: 'text_box_5',
+                  label: 'Text Box default',
+                  title: 'Text Box default',
+                  component: components.TEXT_FIELD,
+                },
+                {
+                  name: 'text_box_6',
+                  label: 'Text Box unvisible',
+                  title: 'Text Box unvisible',
+                  isVisible: false,
+                  component: components.TEXT_FIELD,
+                },
+                {
+                  name: 'text_box_7',
+                  label: 'Text Box with validator',
+                  title: 'Text Box with validator',
+                  validate: [
+                    {
+                      type: validators.PATTERN_VALIDATOR,
+                      pattern: '[0-9]',
+                    },
+                  ],
+                  component: components.TEXT_FIELD,
+                },
+                {
+                  name: 'text_box_8',
+                  label: 'Text Box integer value',
+                  title: 'Text Box integer value',
+                  dataType: 'integer',
+                  component: components.TEXT_FIELD,
+                  type: 'number',
+                },
+                {
+                  name: 'text_box_9',
+                  label: 'Text Box string value',
+                  title: 'Text Box string value',
+                  dataType: 'string',
+                  component: components.TEXT_FIELD,
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+            {
+              title: 'Text areas',
+              key: '638',
+              fields: [
+                {
+                  name: 'textarea_box_1',
+                  label: 'Text Area',
+                  title: 'Text Area',
+                  component: components.TEXTAREA_FIELD,
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+          ],
+          component: components.TAB_ITEM,
+        },
+        {
+          title: 'Tab 2',
+          description: 'Checks',
+          key: '554',
+          fields: [
+            {
+              title: 'Check boxes',
+              key: '639',
+              fields: [
+                {
+                  name: 'check_box_1',
+                  label: 'Check Box',
+                  title: 'Check Box',
+                  component: components.CHECKBOX,
+                },
+                {
+                  name: 'check_box_2',
+                  label: 'Check Box checked',
+                  title: 'Check Box checked',
+                  component: components.CHECKBOX,
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+            {
+              title: 'Radios',
+              key: '640',
+              fields: [
+                {
+                  name: 'radio_button_1',
+                  label: 'Radio Button',
+                  title: 'Radio Button',
+                  dataType: 'string',
+                  component: components.RADIO,
+                  options: [
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                  ],
+                },
+                {
+                  name: 'radio_button_2',
+                  label: 'Radio Button sorted by',
+                  title: 'Radio Button sorted by',
+                  dataType: 'string',
+                  component: components.RADIO,
+                  options: [
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                  ],
+                },
+                {
+                  name: 'radio_button_4',
+                  label: 'Radio Button default',
+                  title: 'Radio Button default',
+                  dataType: 'string',
+                  component: components.RADIO,
+                  options: [
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                  ],
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+          ],
+          component: components.TAB_ITEM,
+        },
+        {
+          title: 'Tab 3',
+          description: '',
+          key: '555',
+          fields: [
+            {
+              title: 'Dropdowns',
+              key: '641',
+              fields: [
+                {
+                  name: 'dropdown_list_1',
+                  label: 'Dropdown',
+                  title: 'Dropdown',
+                  dataType: 'string',
+                  component: components.SELECT_COMPONENT,
+                  options: [
+                    {
+                      label: '<None>',
+                      value: null,
+                    },
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                  ],
+                },
+                {
+                  name: 'dropdown_list_2',
+                  label: 'Dropdown default value',
+                  title: 'Dropdown default value',
+                  dataType: 'string',
+                  component: components.SELECT_COMPONENT,
+                  options: [
+                    {
+                      label: '<None>',
+                      value: null,
+                    },
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                  ],
+                },
+                {
+                  name: 'dropdown_list_3',
+                  label: 'Dropdown multiselect',
+                  title: 'Dropdown multiselect',
+                  dataType: 'string',
+                  component: components.SELECT_COMPONENT,
+                  multi: true,
+                  options: [
+                    {
+                      label: '<None>',
+                      value: null,
+                    },
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                  ],
+                },
+                {
+                  name: 'dropdown_list_4',
+                  label: 'Dropdown sort by value',
+                  title: 'Dropdown sort by value',
+                  dataType: 'string',
+                  component: components.SELECT_COMPONENT,
+                  options: [
+                    {
+                      label: '<None>',
+                      value: null,
+                    },
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                  ],
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+          ],
+          component: components.TAB_ITEM,
+        },
+        {
+          title: 'Tab 4',
+          description: '',
+          key: '556',
+          fields: [
+            {
+              title: 'Datepickers',
+              key: '642',
+              fields: [
+                {
+                  name: 'date_control_1',
+                  label: 'Datepicker',
+                  title: 'Datepicker',
+                  component: components.DATE_PICKER,
+                },
+                {
+                  name: 'date_control_2',
+                  label: 'Datepicker with past days',
+                  title: 'Datepicker with past days',
+                  component: components.DATE_PICKER,
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+            {
+              title: 'Timepickers',
+              key: '643',
+              fields: [
+                {
+                  name: 'date_time_control_1',
+                  label: 'Timepicker',
+                  title: 'Timepicker',
+                  component: components.TIME_PICKER,
+                },
+                {
+                  name: 'date_time_control_2',
+                  label: 'Timepicker with past days',
+                  title: 'Timepicker with past days',
+                  component: components.TIME_PICKER,
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+          ],
+          component: components.TAB_ITEM,
+        },
+        {
+          title: 'Tab 5',
+          description: 'New tab 4',
+          key: '557',
+          fields: [
+            {
+              title: 'Tag control',
+              key: '644',
+              fields: [
+                {
+                  name: 'tag_control_1',
+                  label: 'Tag Control',
+                  title: 'Tag Control',
+                  dataType: 'string',
+                  component: components.TAG_CONTROL,
+                },
+                {
+                  name: 'tag_control_2',
+                  label: 'Tag Control single value',
+                  title: 'Tag Control single value',
+                  dataType: 'string',
+                  component: components.TAG_CONTROL,
+                },
+                {
+                  name: 'tag_control_3',
+                  label: 'Tag Control category',
+                  title: 'Tag Control category',
+                  dataType: 'string',
+                  component: components.TAG_CONTROL,
+                  options: [
+                    {
+
+                    },
+                    {
+
+                    },
+                    {
+
+                    },
+                    {
+
+                    },
+                  ],
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+          ],
+          component: components.TAB_ITEM,
+        },
+        {
+          title: 'Mixed',
+          description: '',
+          key: '558',
+          fields: [
+            {
+              title: 'New Section',
+              key: '645',
+              fields: [
+                {
+                  name: 'text_box_10',
+                  label: 'Text Box',
+                  title: 'Text Box',
+                  component: components.TEXT_FIELD,
+                },
+                {
+                  name: 'textarea_box_2',
+                  label: 'Text Area',
+                  title: 'Text Area',
+                  component: components.TEXTAREA_FIELD,
+                },
+                {
+                  name: 'check_box_3',
+                  label: 'Check Box',
+                  title: 'Check Box',
+                  component: components.CHECKBOX,
+                },
+                {
+                  name: 'check_box_4',
+                  label: 'Check Box',
+                  title: 'Check Box',
+                  component: components.CHECKBOX,
+                },
+                {
+                  name: 'dropdown_list_5',
+                  label: 'Dropdown',
+                  title: 'Dropdown',
+                  dataType: 'string',
+                  component: components.SELECT_COMPONENT,
+                  options: [
+                    {
+                      label: '<None>',
+                      value: null,
+                    },
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                  ],
+                },
+                {
+                  name: 'radio_button_3',
+                  label: 'Radio Button',
+                  title: 'Radio Button',
+                  dataType: 'string',
+                  component: components.RADIO,
+                  options: [
+                    {
+                      label: 'One',
+                      value: '1',
+                    },
+                    {
+                      label: 'Two',
+                      value: '2',
+                    },
+                    {
+                      label: 'Three',
+                      value: '3',
+                    },
+                  ],
+                },
+                {
+                  name: 'date_time_control_3',
+                  label: 'Timepicker',
+                  title: 'Timepicker',
+                  component: components.TIME_PICKER,
+                },
+              ],
+              component: components.SUB_FORM,
+            },
+          ],
+          component: components.TAB_ITEM,
+        },
+      ],
+      component: components.TABS,
+      key: '57',
+    },
+  ],
+};
+
+export const defaultValues = {
+  text_box_5: '"hello"', check_box_2: 'true', radio_button_4: '2', dropdown_list_2: '2',
+};
+
+export default output;

--- a/demo/index.js
+++ b/demo/index.js
@@ -5,7 +5,8 @@ import FormRenderer from '@data-driven-forms/react-form-renderer';
 import { Grid, Row } from 'patternfly-react';
 import { formFieldsMapper, layoutMapper } from '../src'
 import { schema, uiSchema, conditionalSchema, arraySchema, uiArraySchema } from './demo-schemas/widget-schema';
-import miqSchema from './demo-schemas/miq-schema'
+import miqSchema from './demo-schemas/miq-schema';
+import sandbox from './demo-schemas/sandbox';
 
 const App = () => (
     <div>

--- a/src/form-fields/form-fields.js
+++ b/src/form-fields/form-fields.js
@@ -23,6 +23,7 @@ const selectComponent = ({
   label,
   isSearchable,
   FieldProvider,
+  labelText,
   ...rest
 }) => ({
   [componentTypes.TEXT_FIELD]: () => <FormControl { ...input } disabled={ isDisabled } readOnly={ isReadOnly } { ...rest } />,
@@ -65,10 +66,8 @@ const selectComponent = ({
       readonly={ isReadOnly }
       disabled={ isDisabled }
       onChange={ (element, state) => input.onChange(state) }
-      labelText={ label || placeholder }
-    >
-      { label }
-    </Switch>,
+      labelText={ labelText || placeholder }
+    />,
 })[componentType];
 
 const renderHelperText = (error, helperText) => (error // eslint-disable-line no-nested-ternary

--- a/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/src/tests/__snapshots__/form-fields.test.js.snap
@@ -257,7 +257,7 @@ exports[`FormFields should render Switch with label correctly 1`] = `
                   handleWidth="auto"
                   id="someIdKey"
                   inverse={false}
-                  labelText="Label"
+                  labelText=" "
                   labelWidth="auto"
                   name="Name of the field"
                   offColor="default"
@@ -317,7 +317,174 @@ exports[`FormFields should render Switch with label correctly 1`] = `
                           }
                         }
                       >
-                        Label
+                         
+                      </span>
+                      <span
+                        className="bootstrap-switch-handle-off bootstrap-switch-default"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                      >
+                        OFF
+                      </span>
+                    </div>
+                  </div>
+                </Switch>
+              </div>
+            </Col>
+          </div>
+        </FormGroup>
+      </FieldInterface>
+    </div>
+  </FieldProvider>
+</SwitchField>
+`;
+
+exports[`FormFields should render Switch with labelText correctly 1`] = `
+<SwitchField
+  FieldProvider={[Function]}
+  dataType="someDataType"
+  id="someIdKey"
+  input={
+    Object {
+      "name": "Name of the field",
+      "value": "",
+    }
+  }
+  labelText="labelText"
+  meta={
+    Object {
+      "error": false,
+      "touched": false,
+    }
+  }
+>
+  <FieldProvider
+    dataType="someDataType"
+    id="someIdKey"
+    input={
+      Object {
+        "name": "Name of the field",
+        "value": "",
+      }
+    }
+    labelText="labelText"
+    meta={
+      Object {
+        "error": false,
+        "touched": false,
+      }
+    }
+    render={[Function]}
+  >
+    <div>
+      <FieldInterface
+        componentType="switch-field"
+        dataType="someDataType"
+        id="someIdKey"
+        input={
+          Object {
+            "name": "Name of the field",
+            "value": "",
+          }
+        }
+        labelText="labelText"
+        meta={
+          Object {
+            "error": false,
+            "touched": false,
+          }
+        }
+        name="Name of the field"
+      >
+        <FormGroup
+          bsClass="form-group"
+          validationState={null}
+        >
+          <div
+            className="form-group"
+          >
+            <Col
+              bsClass="col"
+              componentClass="div"
+              md={12}
+            >
+              <div
+                className="col-md-12"
+              >
+                <Switch
+                  animate={true}
+                  baseClass="bootstrap-switch"
+                  bsSize={null}
+                  defaultValue={true}
+                  disabled={false}
+                  handleWidth="auto"
+                  id="someIdKey"
+                  inverse={false}
+                  labelText="labelText"
+                  labelWidth="auto"
+                  name="Name of the field"
+                  offColor="default"
+                  offText="OFF"
+                  onChange={[Function]}
+                  onColor="primary"
+                  onText="ON"
+                  readonly={false}
+                  tristate={false}
+                  value={false}
+                  wrapperClass="wrapper"
+                >
+                  <div
+                    className="bootstrap-switch wrapper bootstrap-switch-off bootstrap-switch-someIdKey"
+                    onBlur={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    style={
+                      Object {
+                        "width": "auto",
+                      }
+                    }
+                    tabIndex="0"
+                  >
+                    <div
+                      className="bootstrap-switch-container"
+                      style={
+                        Object {
+                          "marginLeft": -0,
+                          "width": "auto",
+                        }
+                      }
+                    >
+                      <span
+                        className="bootstrap-switch-handle-on bootstrap-switch-primary"
+                        onClick={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                      >
+                        ON
+                      </span>
+                      <span
+                        className="bootstrap-switch-label"
+                        onMouseDown={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        onMouseUp={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchMove={[Function]}
+                        onTouchStart={[Function]}
+                        style={
+                          Object {
+                            "width": 0,
+                          }
+                        }
+                      >
+                        labelText
                       </span>
                       <span
                         className="bootstrap-switch-handle-off bootstrap-switch-default"
@@ -521,13 +688,13 @@ exports[`FormFields should render Switch with placeholder correctly 1`] = `
       "value": "",
     }
   }
-  label="Placeholder"
   meta={
     Object {
       "error": false,
       "touched": false,
     }
   }
+  placeholder="Placeholder"
 >
   <FieldProvider
     dataType="someDataType"
@@ -538,13 +705,13 @@ exports[`FormFields should render Switch with placeholder correctly 1`] = `
         "value": "",
       }
     }
-    label="Placeholder"
     meta={
       Object {
         "error": false,
         "touched": false,
       }
     }
+    placeholder="Placeholder"
     render={[Function]}
   >
     <div>
@@ -558,7 +725,6 @@ exports[`FormFields should render Switch with placeholder correctly 1`] = `
             "value": "",
           }
         }
-        label="Placeholder"
         meta={
           Object {
             "error": false,
@@ -566,6 +732,7 @@ exports[`FormFields should render Switch with placeholder correctly 1`] = `
           }
         }
         name="Name of the field"
+        placeholder="Placeholder"
       >
         <FormGroup
           bsClass="form-group"
@@ -576,23 +743,11 @@ exports[`FormFields should render Switch with placeholder correctly 1`] = `
           >
             <Col
               bsClass="col"
-              className="control-label"
-              componentClass="label"
-              md={2}
-            >
-              <label
-                className="control-label col-md-2"
-              >
-                Placeholder
-              </label>
-            </Col>
-            <Col
-              bsClass="col"
               componentClass="div"
-              md={10}
+              md={12}
             >
               <div
-                className="col-md-10"
+                className="col-md-12"
               >
                 <Switch
                   animate={true}

--- a/src/tests/form-fields.test.js
+++ b/src/tests/form-fields.test.js
@@ -35,7 +35,14 @@ describe('FormFields', () => {
 
   it('should render Switch with placeholder correctly', () => {
     const wrapper = mount(
-      <SwitchField { ...props } label={ 'Placeholder' } FieldProvider={ FieldProvider } />
+      <SwitchField { ...props } placeholder={ 'Placeholder' } FieldProvider={ FieldProvider } />
+    );
+    expect(toJson(wrapper)).toMatchSnapshot();
+  });
+
+  it('should render Switch with labelText correctly', () => {
+    const wrapper = mount(
+      <SwitchField { ...props } labelText={ 'labelText' } FieldProvider={ FieldProvider } />
     );
     expect(toJson(wrapper)).toMatchSnapshot();
   });


### PR DESCRIPTION
* Removes label as a 'placeholder' for the switch component (it doesn't work well)
* Adds labelText as in Bootstrap Switch API ( :thinking: :thought_balloon:   )
* Removes switch children ( :skull:  :gun: )
* Adds 'sandbox' demoScheme - for quick editing pure schema and testing it