### PR TITLE
fix(DatePicker) moved events onMouseDown from onClick.

### DIFF
--- a/src/form-fields/date-time-picker/navbar.js
+++ b/src/form-fields/date-time-picker/navbar.js
@@ -8,7 +8,7 @@ const Navbar = ({ onNextClick, onPreviousClick, month, onMonthClick, isYear, tog
   <table className="year-interval-header">
     <tbody>
       <tr>
-        <td className={ disablePrev ? 'disabled' : '' } onClick={ () => !disablePrev && onPreviousClick() }>
+        <td className={ disablePrev ? 'disabled' : '' } onMouseDown={ () => !disablePrev && onPreviousClick() }>
           <Icon name="angle-left"><span>Prev interval</span></Icon>
         </td>
         <td>
@@ -17,13 +17,14 @@ const Navbar = ({ onNextClick, onPreviousClick, month, onMonthClick, isYear, tog
             : (
               <button
                 className="navbar-center-button"
-                type="button" onClick={ () => onMonthClick(true) }
+                onMouseDown={ () => { onMonthClick(true);} }
+                type="button" onClick={ () => {} }
               >
                 { MomentLocaleUtils.formatMonthTitle(month, locale) }
               </button>
             ) }
         </td>
-        <td className={ disableNext ? 'disabled' : '' } onClick={ () =>!disableNext &&  onNextClick() }>
+        <td className={ disableNext ? 'disabled' : '' } onMouseDown={ () =>!disableNext &&  onNextClick() }>
           <Icon name="angle-right" ><span>Next interval</span></Icon>
         </td>
       </tr>

--- a/src/tests/form-fields/date-time-picker/navbar.test.js
+++ b/src/tests/form-fields/date-time-picker/navbar.test.js
@@ -25,21 +25,21 @@ describe('<Navbar />', () => {
   it('should call previsouse click prop', () => {
     const onPreviousClick = jest.fn();
     const wrapper = mount(<Navbar { ...initialProps } onPreviousClick={ onPreviousClick } />);
-    wrapper.find('td').first().simulate('click');
+    wrapper.find('td').first().simulate('mousedown');
     expect(onPreviousClick).toHaveBeenCalled();
   });
 
   it('should call next click prop', () => {
     const onNextClick = jest.fn();
     const wrapper = mount(<Navbar { ...initialProps } onNextClick={ onNextClick } />);
-    wrapper.find('td').last().simulate('click');
+    wrapper.find('td').last().simulate('mousedown');
     expect(onNextClick).toHaveBeenCalled();
   });
 
   it('should call onMonthClick click prop', () => {
     const onMonthClick = jest.fn();
     const wrapper = mount(<Navbar { ...initialProps } onMonthClick={ onMonthClick } />);
-    wrapper.find('button.navbar-center-button').simulate('click');
+    wrapper.find('button.navbar-center-button').simulate('mousedown');
     expect(onMonthClick).toHaveBeenCalledWith(true);
   });
 


### PR DESCRIPTION
For some reason datepicker navbar for months was not registering onClick events in build. I have no clue why is that but moving onClick events to onMouseDown fixes the issue.