### PR TITLE
fix(formOptions): added formOptions to radio/checkboxes.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.0.0",
     "@babel/preset-env": "^7.1.6",
     "@babel/preset-react": "^7.0.0",
-    "@data-driven-forms/react-form-renderer": "^1.7.0",
+    "@data-driven-forms/react-form-renderer": "^1.9.3",
     "@semantic-release/git": "^7.0.5",
     "@semantic-release/npm": "^5.1.1",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/form-fields/form-fields.js
+++ b/src/form-fields/form-fields.js
@@ -41,6 +41,7 @@ const selectComponent = ({
       name={ input.name }
       value={ option.value }
       type="radio"
+      formOptions={ formOptions }
       render={ ({ input }) => (
         <PfRadio { ...input } onChange={ () => { input.onChange(option.value); } } disabled={ isDisabled || isReadOnly }>{ option.label }</PfRadio>) }
     />
@@ -124,7 +125,7 @@ const CheckboxGroupField = ({ options, ...rest }) =>
 
 const fieldMapper = type => ({
   [componentTypes.RADIO]: FinalFormField,
-  [componentTypes.CHECKBOX]: props => <CheckboxGroupField { ...props } />,
+  [componentTypes.CHECKBOX]: CheckboxGroupField,
   [componentTypes.SELECT_COMPONENT]: FinalFormField,
   [componentTypes.TEXTAREA_FIELD]: FinalFormField,
   [componentTypes.TEXT_FIELD]: FinalFormField,

--- a/src/form-fields/multiple-choice-list.js
+++ b/src/form-fields/multiple-choice-list.js
@@ -26,12 +26,13 @@ const MultipleChoiceList = ({ validate, FieldProvider, ...props }) => (
           <Col md={ 10 }>
             { options.map(option =>
               (<FieldProvider
+                { ...rest }
                 id={ `${rest.id}-${option.value}` }
                 key={ option.value }
                 { ...option }
                 name={ props.name }
                 type="checkbox"
-                render={ ({ input, meta, ...rest }) => {
+                render={ ({ input, meta, formOptions, componentType, ...rest }) => {
                   const indexValue = groupValues.indexOf(input.value);
                   return (
                     <Checkbox

--- a/src/tests/__snapshots__/form-fields.test.js.snap
+++ b/src/tests/__snapshots__/form-fields.test.js.snap
@@ -21,7 +21,7 @@ exports[`FormFields <CheckboxGroup /> should render single checkbox variant 1`] 
     meta={Object {}}
     name="single-check-box"
   >
-    <CheckboxGroupField
+    <FinalFormField
       FieldProvider={[Function]}
       componentType="checkbox"
       id="single-check-box"
@@ -32,62 +32,49 @@ exports[`FormFields <CheckboxGroup /> should render single checkbox variant 1`] 
       }
       meta={Object {}}
       name="single-check-box"
+      noCheckboxLabel={true}
     >
-      <FinalFormField
-        FieldProvider={[Function]}
-        componentType="checkbox"
-        id="single-check-box"
-        input={
-          Object {
-            "name": "single-check-box",
-          }
-        }
-        meta={Object {}}
-        name="single-check-box"
-        noCheckboxLabel={true}
+      <FormGroup
+        bsClass="form-group"
+        validationState={null}
       >
-        <FormGroup
-          bsClass="form-group"
-          validationState={null}
+        <div
+          className="form-group"
         >
-          <div
-            className="form-group"
+          <Col
+            bsClass="col"
+            componentClass="div"
+            md={12}
           >
-            <Col
-              bsClass="col"
-              componentClass="div"
-              md={12}
+            <div
+              className="col-md-12"
             >
-              <div
-                className="col-md-12"
+              <Checkbox
+                bsClass="checkbox"
+                disabled={false}
+                inline={false}
+                name="single-check-box"
+                title=""
               >
-                <Checkbox
-                  bsClass="checkbox"
-                  disabled={false}
-                  inline={false}
-                  name="single-check-box"
-                  title=""
+                <div
+                  className="checkbox"
                 >
-                  <div
-                    className="checkbox"
+                  <label
+                    title=""
                   >
-                    <label
-                      title=""
-                    >
-                      <input
-                        disabled={false}
-                        name="single-check-box"
-                        type="checkbox"
-                      />
-                    </label>
-                  </div>
-                </Checkbox>
-              </div>
-            </Col>
-          </div>
-        </FormGroup>
-      </FinalFormField>
-    </CheckboxGroupField>
+                    <input
+                      disabled={false}
+                      name="single-check-box"
+                      type="checkbox"
+                    />
+                  </label>
+                </div>
+              </Checkbox>
+            </div>
+          </Col>
+        </div>
+      </FormGroup>
+    </FinalFormField>
   </FieldInterface>
 </CheckboxGroup>
 `;

--- a/src/tests/__snapshots__/multiple-choice-list.test.js.snap
+++ b/src/tests/__snapshots__/multiple-choice-list.test.js.snap
@@ -79,10 +79,17 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
             >
               <FieldProvider
                 id="undefined-0"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 key="0"
                 label="Foo"
                 render={[Function]}
                 type="checkbox"
+                validate={[Function]}
                 value={0}
               >
                 <MockFieldProvider
@@ -96,6 +103,7 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
                   label="Foo"
                   render={[Function]}
                   type="checkbox"
+                  validate={[Function]}
                   value={0}
                 >
                   <Checkbox
@@ -108,6 +116,7 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
                     onChange={[Function]}
                     title=""
                     type="checkbox"
+                    validate={[Function]}
                     value={0}
                   >
                     <div
@@ -123,6 +132,7 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
                           label="Foo"
                           onChange={[Function]}
                           type="checkbox"
+                          validate={[Function]}
                           value={0}
                         />
                         Foo
@@ -133,10 +143,17 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
               </FieldProvider>
               <FieldProvider
                 id="undefined-1"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 key="1"
                 label="Bar"
                 render={[Function]}
                 type="checkbox"
+                validate={[Function]}
                 value={1}
               >
                 <MockFieldProvider
@@ -150,6 +167,7 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
                   label="Bar"
                   render={[Function]}
                   type="checkbox"
+                  validate={[Function]}
                   value={1}
                 >
                   <Checkbox
@@ -162,6 +180,7 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
                     onChange={[Function]}
                     title=""
                     type="checkbox"
+                    validate={[Function]}
                     value={1}
                   >
                     <div
@@ -177,6 +196,7 @@ exports[`<MultipleChoiceList /> should render correctly 1`] = `
                           label="Bar"
                           onChange={[Function]}
                           type="checkbox"
+                          validate={[Function]}
                           value={1}
                         />
                         Bar
@@ -279,10 +299,17 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
             >
               <FieldProvider
                 id="undefined-0"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 key="0"
                 label="Foo"
                 render={[Function]}
                 type="checkbox"
+                validate={[Function]}
                 value={0}
               >
                 <MockFieldProvider
@@ -302,6 +329,7 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
                   }
                   render={[Function]}
                   type="checkbox"
+                  validate={[Function]}
                   value={0}
                 >
                   <Checkbox
@@ -314,6 +342,7 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
                     onChange={[Function]}
                     title=""
                     type="checkbox"
+                    validate={[Function]}
                     value={0}
                   >
                     <div
@@ -329,6 +358,7 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
                           label="Foo"
                           onChange={[Function]}
                           type="checkbox"
+                          validate={[Function]}
                           value={0}
                         />
                         Foo
@@ -339,10 +369,17 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
               </FieldProvider>
               <FieldProvider
                 id="undefined-1"
+                input={
+                  Object {
+                    "onChange": [MockFunction],
+                    "value": Array [],
+                  }
+                }
                 key="1"
                 label="Bar"
                 render={[Function]}
                 type="checkbox"
+                validate={[Function]}
                 value={1}
               >
                 <MockFieldProvider
@@ -362,6 +399,7 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
                   }
                   render={[Function]}
                   type="checkbox"
+                  validate={[Function]}
                   value={1}
                 >
                   <Checkbox
@@ -374,6 +412,7 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
                     onChange={[Function]}
                     title=""
                     type="checkbox"
+                    validate={[Function]}
                     value={1}
                   >
                     <div
@@ -389,6 +428,7 @@ exports[`<MultipleChoiceList /> should render in error state 1`] = `
                           label="Bar"
                           onChange={[Function]}
                           type="checkbox"
+                          validate={[Function]}
                           value={1}
                         />
                         Bar


### PR DESCRIPTION
https://github.com/data-driven-forms/react-form-renderer/pull/36 introduced option to delete value from form state. But this requires passing formOptions to custom FieldProviders. 

https://github.com/data-driven-forms/react-form-renderer/pull/37 added fallbakc options that will prevent crashes but we want this feature even form chekboxes and radio buttons.